### PR TITLE
Load only for Go files, and some minor tweaks.

### DIFF
--- a/plugin/sourcegraph.vim
+++ b/plugin/sourcegraph.vim
@@ -29,12 +29,12 @@ function! LookupSymbol()
 		let s:startup = "false"
 	endif
 
-	let s:filename = expand('%p')
+	let s:filename = expand('%:p')
 	let s:currword = expand('<cWORD>')
 	let s:currword_small = expand('<cword>')
-	let s:curroffset = line2byte(line("."))+col(".")-1
-	let s:numlines = expand(line('$'))
-	let s:linenumber = expand(line("."))
+	let s:curroffset = line2byte(line(".")) + col(".") - 1
+	let s:numlines = line('$')
+	let s:linenumber = line('.')
 	if s:filename == s:last_filename && s:currword_small == s:last_word_small && s:linenumber == s:last_linenumber
 	else
 		let s:last_filename = s:filename

--- a/plugin/sourcegraph.vim
+++ b/plugin/sourcegraph.vim
@@ -1,4 +1,4 @@
-let s:path = fnamemodify(resolve(expand('<sfile>:p')), ':h')."/sourcegraph_vi.py"
+let s:path = fnamemodify(resolve(expand('<sfile>:p')), ':h') . "/sourcegraph_vi.py"
 
 if !has('python')
 	finish
@@ -6,14 +6,14 @@ endif
 
 let s:startup = "true"
 
-if (has('python') && (!exists("g:SOURCEGRAPH_AUTO") || g:SOURCEGRAPH_AUTO == "true"))
+if !exists("g:SOURCEGRAPH_AUTO") || g:SOURCEGRAPH_AUTO == "true"
     augroup SourcegraphVim
-        autocmd VimEnter     * :call LookupSymbol()
-        autocmd VimLeavePre  * :call LookupSymbol()
-        autocmd CursorMoved  * :call LookupSymbol()
-        autocmd CursorMovedI * :call LookupSymbol()
-        autocmd BufEnter     * :call LookupSymbol()
-        autocmd BufLeave     * :call LookupSymbol()
+        autocmd VimEnter     *.go call LookupSymbol()
+        autocmd VimLeavePre  *.go call LookupSymbol()
+        autocmd CursorMoved  *.go call LookupSymbol()
+        autocmd CursorMovedI *.go call LookupSymbol()
+        autocmd BufEnter     *.go call LookupSymbol()
+        autocmd BufLeave     *.go call LookupSymbol()
     augroup END
 endif
 
@@ -23,34 +23,27 @@ let s:last_word_small = ''
 let s:last_offset = 0
 let s:last_linenumber = -1
 
-au BufNewFile,BufRead *.go set filetype=go
-
 function! LookupSymbol()
-	echo ""
-	if (&ft=='go')
-		
-		if (s:startup == "true")
-			execute "pyfile " . s:path
-			let s:startup = "false"
-		endif
-
-    	let s:filename = expand('%p')
-		let s:currword = expand('<cWORD>')
-		let s:currword_small = expand('<cword>')
-		let s:curroffset = line2byte(line("."))+col(".")-1
-		let s:numlines = expand(line('$'))
-		let s:linenumber = expand(line("."))
-		if(s:filename==s:last_filename && s:currword_small==s:last_word_small && s:linenumber==s:last_linenumber)
-		else
-			let s:last_filename = s:filename
-			let s:last_word = s:currword
-			let s:last_word_small = s:currword_small
-			let s:last_offset = s:curroffset
-			let s:last_linenumber = s:linenumber
-			execute "pyfile " . s:path
-		endif
+	if s:startup == "true"
+		execute "pyfile " . s:path
+		let s:startup = "false"
 	endif
-endfunc
+
+	let s:filename = expand('%p')
+	let s:currword = expand('<cWORD>')
+	let s:currword_small = expand('<cword>')
+	let s:curroffset = line2byte(line("."))+col(".")-1
+	let s:numlines = expand(line('$'))
+	let s:linenumber = expand(line("."))
+	if s:filename == s:last_filename && s:currword_small == s:last_word_small && s:linenumber == s:last_linenumber
+	else
+		let s:last_filename = s:filename
+		let s:last_word = s:currword
+		let s:last_word_small = s:currword_small
+		let s:last_offset = s:curroffset
+		let s:last_linenumber = s:linenumber
+		execute "pyfile " . s:path
+	endif
+endfunction
 
 command! GRAPH call LookupSymbol()
-


### PR DESCRIPTION
- Before it would load for *every* file, and while it would check for the
  `filetype` in the function body, this is sort of the standard way to do this.

- Also don't reset the filetype. What if I'm using a modified `mygolang`
  FileType?

- I also tweaked the code a bit to resemble more like standard/idiomatic
  VimScript (insofar such a thing exists).

- Remove the redundant echo mentioned in #4